### PR TITLE
Add section to let CMake manage the Kokkos dependency

### DIFF
--- a/install.md
+++ b/install.md
@@ -40,14 +40,13 @@ title: Installation cheat sheet for Kokkos
 | CMake        | 3.18            | For better Fortran linking  |
 | CMake        | 3.16            |                             |
 
-
 <!--#ifndef PRINT-->
 <img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/requirements.html
 <!--#endif-->
 
 ## How to build Kokkos
 
-### As part of your application
+### As a sub-directory dependency
 
 ```cmake
 add_subdirectory(path/to/kokkos)
@@ -64,24 +63,22 @@ cmake -B build \
     <Kokkos compile options>
 ```
 
-<!--#ifndef PRINT-->
-<img title="Code" alt="Code" src="./images/code_txt.svg" height="25"> Code example:
+You may want to provide Kokkos as a Git submodule.
 
-- https://github.com/kokkos/kokkos/tree/master/example/build_cmake_in_tree
+<!--#ifndef PRINT-->
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/integrating-kokkos-into-your-cmake-project.html#embedded-kokkos-via-add-subdirectory-and-git-submodules
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://cmake.org/cmake/help/latest/command/add_subdirectory.html#command:add_subdirectory
 <!--#endif-->
 
-### As a dependency managed by CMake
+### As an online dependency
 
 ```cmake
-find_package(Kokkos CONFIG)
-if(NOT Kokkos_FOUND)
-    include(FetchContent)
-    FetchContent_Declare(
-        kokkos
-        URL https://github.com/kokkos/kokkos/releases/download/x.y.z/kokkos-x.y.z.zip
-    )
-    FetchContent_MakeAvailable(kokkos)
-endif()
+include(FetchContent)
+FetchContent_Declare(
+    kokkos
+    URL https://github.com/kokkos/kokkos/releases/download/x.y.z/kokkos-x.y.z.zip
+)
+FetchContent_MakeAvailable(kokkos)
 target_link_libraries(
     my-app
     Kokkos::kokkos
@@ -95,7 +92,12 @@ cmake -B build \
     <Kokkos compile options>
 ```
 
-### As an external library
+<!--#ifndef PRINT-->
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/integrating-kokkos-into-your-cmake-project.html#embedded-kokkos-via-fetchcontent
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://cmake.org/cmake/help/latest/module/FetchContent.html
+<!--#endif-->
+
+### As an external dependency
 
 #### Configure, build and install Kokkos
 
@@ -109,14 +111,10 @@ cmake --build build
 cmake --install build
 ```
 
-<!--#ifndef PRINT-->
-<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/building.html
-<!--#endif-->
-
 #### Use in your code
 
 ```cmake
-find_package(Kokkos REQUIRED)
+find_package(Kokkos x.y.z REQUIRED)
 target_link_libraries(
     my-app
     Kokkos::kokkos
@@ -131,8 +129,23 @@ cmake -B build \
 ```
 
 <!--#ifndef PRINT-->
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/integrating-kokkos-into-your-cmake-project.html#external-kokkos-recommended-for-most-users
 <img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://cmake.org/cmake/help/latest/guide/tutorial/index.html
 <!--#endif-->
+
+### As an external or sub-directory/online dependency
+
+```cmake
+find_package(Kokkos x.y.z QUIET)
+if(Kokkos_FOUND)
+    message(STATUS "Using installed Kokkos in ${Kokkos_DIR}")
+else()
+    message(STATUS "Using Kokkos from ...")
+    # use either the sub-directory or the online dependency approach
+endif()
+```
+
+Depending if Kokkos is already installed, you may have to call CMake with `-DKokkos_ROOT`, or with Kokkos compile options.
 
 <!--#ifndef PRINT-->
 

--- a/install.md
+++ b/install.md
@@ -46,6 +46,8 @@ title: Installation cheat sheet for Kokkos
 
 ## How to integrate Kokkos
 
+Note the difference in the version number between `x.y.z` and `x.y.zz`.
+
 ### As an external dependency
 
 #### Configure, build and install Kokkos

--- a/install.md
+++ b/install.md
@@ -6,9 +6,9 @@ title: Installation cheat sheet for Kokkos
 
 # Kokkos install cheat sheet
 
-<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/ProgrammingGuide/Compiling.html
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/quick-start.html
 
-<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/building.html
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/ProgrammingGuide/Compiling.html
 
 <img title="Doc" alt="Doc" src="./images/tutorial_txt.svg" height="25"> https://github.com/kokkos/kokkos-tutorials/blob/main/LectureSeries/KokkosTutorial_01_Introduction.pdf
 
@@ -41,7 +41,7 @@ title: Installation cheat sheet for Kokkos
 | CMake        | 3.16            |                             |
 
 <!--#ifndef PRINT-->
-<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/requirements.html
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/requirements.html
 <!--#endif-->
 
 ## How to build Kokkos
@@ -153,7 +153,7 @@ Depending if Kokkos is already installed, you may have to call CMake with `-DKok
 
 TODO finish this part
 
-<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> See https://kokkos.org/kokkos-core-wiki/building.html#spack
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/package-managers.html?highlight=spack#spack-https-spack-io
 
 <!--#endif-->
 
@@ -203,7 +203,7 @@ See [architecture-specific options](#architecture-specific-options).
 
 </details>
 
-<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> For more, see https://kokkos.org/kokkos-core-wiki/keywords.html
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/configuration-guide.html
 <!--#endif-->
 
 ### Architecture-specific options
@@ -384,7 +384,7 @@ They can be deduced from the device if present at CMake configuration time.
 <!--#ifndef PRINT-->
 ### Third-party Libraries (TPLs)
 
-<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25">  See https://kokkos.org/kokkos-core-wiki/keywords.html#third-party-libraries-tpls
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/configuration-guide.html#keywords-tpls
 <!--#endif-->
 
 ### Examples for the most common architectures

--- a/install.md
+++ b/install.md
@@ -51,7 +51,8 @@ title: Installation cheat sheet for Kokkos
 #### Configure, build and install Kokkos
 
 ```sh
-cd path/to/kokkos
+git clone -b x.y.zz https://github.com/kokkos/kokkos.git
+cd kokkos
 cmake -B build \
     -DCMAKE_CXX_COMPILER=<your C++ compiler> \
     -DCMAKE_INSTALL_PREFIX=path/to/kokkos/install \

--- a/install.md
+++ b/install.md
@@ -44,58 +44,7 @@ title: Installation cheat sheet for Kokkos
 <img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/requirements.html
 <!--#endif-->
 
-## How to build Kokkos
-
-### As a sub-directory dependency
-
-```cmake
-add_subdirectory(path/to/kokkos)
-target_link_libraries(
-    my-app
-    Kokkos::kokkos
-)
-```
-
-```sh
-cd path/to/your/code
-cmake -B build \
-    -DCMAKE_CXX_COMPILER=<your C++ compiler> \
-    <Kokkos compile options>
-```
-
-You may want to provide Kokkos as a Git submodule.
-
-<!--#ifndef PRINT-->
-<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/integrating-kokkos-into-your-cmake-project.html#embedded-kokkos-via-add-subdirectory-and-git-submodules
-<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://cmake.org/cmake/help/latest/command/add_subdirectory.html#command:add_subdirectory
-<!--#endif-->
-
-### As an online dependency
-
-```cmake
-include(FetchContent)
-FetchContent_Declare(
-    kokkos
-    URL https://github.com/kokkos/kokkos/releases/download/x.y.z/kokkos-x.y.z.zip
-)
-FetchContent_MakeAvailable(kokkos)
-target_link_libraries(
-    my-app
-    Kokkos::kokkos
-)
-```
-
-```sh
-cd path/to/your/code
-cmake -B build \
-    -DCMAKE_CXX_COMPILER=<your C++ compiler> \
-    <Kokkos compile options>
-```
-
-<!--#ifndef PRINT-->
-<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/integrating-kokkos-into-your-cmake-project.html#embedded-kokkos-via-fetchcontent
-<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://cmake.org/cmake/help/latest/module/FetchContent.html
-<!--#endif-->
+## How to integrate Kokkos
 
 ### As an external dependency
 
@@ -111,7 +60,7 @@ cmake --build build
 cmake --install build
 ```
 
-#### Use in your code
+#### Setup, and configure your code
 
 ```cmake
 find_package(Kokkos x.y.z REQUIRED)
@@ -133,7 +82,62 @@ cmake -B build \
 <img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://cmake.org/cmake/help/latest/guide/tutorial/index.html
 <!--#endif-->
 
-### As an external or sub-directory/online dependency
+### As an internal dependency
+
+#### Setup with a Git submodule
+
+```sh
+git submodule add -b x.y.zz https://github.com/kokkos/kokkos.git tpls/kokkos
+```
+
+```cmake
+add_subdirectory(path/to/kokkos)
+target_link_libraries(
+    my-app
+    Kokkos::kokkos
+)
+```
+
+<!--#ifndef PRINT-->
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/integrating-kokkos-into-your-cmake-project.html#embedded-kokkos-via-add-subdirectory-and-git-submodules
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://cmake.org/cmake/help/latest/command/add_subdirectory.html#command:add_subdirectory
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://git-scm.com/book/en/v2/Git-Tools-Submodules
+<!--#endif-->
+
+#### Setup with FetchContent
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+    kokkos
+    URL https://github.com/kokkos/kokkos/releases/download/x.y.zz/kokkos-x.y.zz.tar.gz
+    URL_HASH SHA256=<hash for x.y.z archive>
+)
+FetchContent_MakeAvailable(kokkos)
+target_link_libraries(
+    my-app
+    Kokkos::kokkos
+)
+```
+
+#### Configure your code
+
+```sh
+cmake -B build \
+    -DCMAKE_CXX_COMPILER=<your C++ compiler> \
+    <Kokkos compile options>
+```
+
+You may combine the external/internal dependency approaches.
+
+<!--#ifndef PRINT-->
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/integrating-kokkos-into-your-cmake-project.html#embedded-kokkos-via-fetchcontent
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://cmake.org/cmake/help/latest/module/FetchContent.html
+<!--#endif-->
+
+<!--#ifndef PRINT-->
+
+### As an external or internal dependency
 
 ```cmake
 find_package(Kokkos x.y.z QUIET)
@@ -141,11 +145,14 @@ if(Kokkos_FOUND)
     message(STATUS "Using installed Kokkos in ${Kokkos_DIR}")
 else()
     message(STATUS "Using Kokkos from ...")
-    # use either the sub-directory or the online dependency approach
+    # with either a Git submodule or FetchContent
 endif()
 ```
 
 Depending if Kokkos is already installed, you may have to call CMake with `-DKokkos_ROOT`, or with Kokkos compile options.
+
+<img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/integrating-kokkos-into-your-cmake-project.html#supporting-both-external-and-embedded-kokkos
+<!--#endif-->
 
 <!--#ifndef PRINT-->
 
@@ -411,7 +418,7 @@ cmake \
     -DKokkos_ARCH_AMD_GFX942_APU=ON
 ```
 
-Environment variable is required to access host allocations from the device.
+The environment variable is required to access host allocations from the device.
 
 #### AMD MI250 GPU with HIP
 
@@ -436,7 +443,7 @@ cmake \
     -DCMAKE_CXX_FLAGS="-fp-model=precise"
 ```
 
-Last option is for math operators precision.
+The last option is required for math operators precision.
 
 #### NVIDIA H100 GPU with CUDA
 

--- a/install.md
+++ b/install.md
@@ -153,6 +153,7 @@ endif()
 ```
 
 Depending if Kokkos is already installed, you may have to call CMake with `-DKokkos_ROOT`, or with Kokkos compile options.
+Note that this setup may not scale for a library, you should use a package manager instead.
 
 <img title="Doc" alt="Doc" src="./images/doc_txt.svg" height="25"> https://kokkos.org/kokkos-core-wiki/get-started/integrating-kokkos-into-your-cmake-project.html#supporting-both-external-and-embedded-kokkos
 <!--#endif-->

--- a/install.md
+++ b/install.md
@@ -70,6 +70,31 @@ cmake -B build \
 - https://github.com/kokkos/kokkos/tree/master/example/build_cmake_in_tree
 <!--#endif-->
 
+### As a dependency managed by CMake
+
+```cmake
+find_package(Kokkos CONFIG)
+if(NOT Kokkos_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+        kokkos
+        URL https://github.com/kokkos/kokkos/releases/download/x.y.z/kokkos-x.y.z.zip
+    )
+    FetchContent_MakeAvailable(kokkos)
+endif()
+target_link_libraries(
+    my-app
+    Kokkos::kokkos
+)
+```
+
+```sh
+cd path/to/your/code
+cmake -B build \
+    -DCMAKE_CXX_COMPILER=<your C++ compiler> \
+    <Kokkos compile options>
+```
+
 ### As an external library
 
 #### Configure, build and install Kokkos

--- a/patches/print/install.tex.diff
+++ b/patches/print/install.tex.diff
@@ -1,15 +1,15 @@
---- .install.tex	2025-02-28 15:37:52.208429178 +0100
-+++ install.tex	2025-02-28 15:38:14.746538842 +0100
-@@ -471,7 +471,7 @@
+--- .install.tex	2025-04-29 15:05:59.861833564 +0200
++++ install.tex	2025-04-29 15:09:46.159589195 +0200
+@@ -591,7 +591,7 @@
  \KeywordTok{include}\NormalTok{(FetchContent)}
  \FunctionTok{FetchContent\_Declare}\NormalTok{(}
  \NormalTok{    kokkos}
--\NormalTok{    URL https://github.com/kokkos/kokkos/releases/download/x.y.z/kokkos{-}x.y.z.zip}
-+\NormalTok{    URL https://github.com/kokkos/kokkos/releases/download/x.y.z/\break{}kokkos{-}x.y.z.zip}
+-\NormalTok{    URL https://github.com/kokkos/kokkos/releases/download/x.y.zz/kokkos{-}x.y.zz.tar.gz}
++\NormalTok{    URL https://github.com/kokkos/kokkos/releases/download/x.y.zz\break{}/kokkos{-}x.y.zz.tar.gz}
+ \NormalTok{    URL\_HASH SHA256=\textless{}hash for x.y.z archive\textgreater{}}
  \NormalTok{)}
  \FunctionTok{FetchContent\_MakeAvailable}\NormalTok{(kokkos)}
- \KeywordTok{target\_link\_libraries}\NormalTok{(}
-@@ -645,7 +645,7 @@
+@@ -709,7 +709,7 @@
  \begin{tabularx}{\linewidth}{llX}
  \toprule
  
@@ -18,7 +18,7 @@
  cards} \\ \midrule
  
  \texttt{-DKokkos\_ARCH\_AMD\_GFX942\_APU=ON} & GFX942 APU & MI300A \\
-@@ -688,7 +688,7 @@
+@@ -752,7 +752,7 @@
  \begin{tabularx}{\linewidth}{lllX}
  \toprule
  
@@ -27,3 +27,19 @@
  cards} \\ \midrule
  
  \texttt{-DKokkos\_ARCH\_HOPPER90=ON} & Hopper & 9.0 & H200, H100 \\
+@@ -766,6 +766,15 @@
+ \texttt{-DKokkos\_ARCH\_VOLTA70=ON} & Volta & 7.0 & V100 \\
+ \texttt{-DKokkos\_ARCH\_PASCAL61=ON} & Pascal & 6.1 & P6, P40, P4 \\
+ \texttt{-DKokkos\_ARCH\_PASCAL60=ON} & Pascal & 6.0 & P100 \\
++\bottomrule
++\end{tabularx}
++
++\begin{tabularx}{\linewidth}{lllX}
++\toprule
++
++\tblhead{Option} & \tblhead{Arch.} & \tblhead{CC} & \tblhead{Associated
++cards} \\ \midrule
++
+ \texttt{-DKokkos\_ARCH\_MAXWELL53=ON} & Maxwell & 5.3 &  \\
+ \texttt{-DKokkos\_ARCH\_MAXWELL52=ON} & Maxwell & 5.2 & M6, M60, M4,
+ M40 \\

--- a/patches/print/install.tex.diff
+++ b/patches/print/install.tex.diff
@@ -1,6 +1,15 @@
---- .install.tex	2024-06-11 16:45:25.798270906 +0200
-+++ install.tex	2024-06-11 16:45:51.158407213 +0200
-@@ -497,7 +497,7 @@
+--- .install.tex	2025-02-21 20:31:49.235182630 +0100
++++ install.tex	2025-02-21 20:32:21.670428339 +0100
+@@ -472,7 +472,7 @@
+     \KeywordTok{include}\NormalTok{(FetchContent)}
+     \FunctionTok{FetchContent\_Declare}\NormalTok{(}
+ \NormalTok{        kokkos}
+-\NormalTok{        URL https://github.com/kokkos/kokkos/releases/download/x.y.z/kokkos{-}x.y.z.zip}
++\NormalTok{        URL https://github.com/kokkos/kokkos/releases/download/x.y.z/\break{}kokkos{-}x.y.z.zip}
+ \NormalTok{    )}
+     \FunctionTok{FetchContent\_MakeAvailable}\NormalTok{(kokkos)}
+ \KeywordTok{endif}\NormalTok{()}
+@@ -627,7 +627,7 @@
  \begin{tabularx}{\linewidth}{llX}
  \toprule
  
@@ -8,8 +17,8 @@
 +\tblhead{Option} & \tblhead{Arch.} & \tblhead{Associated
  cards} \\ \midrule
  
- \texttt{-DKokkos\_ARCH\_AMD\_GFX942=ON} & GFX942 & MI300A, MI300X \\
-@@ -537,7 +537,7 @@
+ \texttt{-DKokkos\_ARCH\_AMD\_GFX942\_APU=ON} & GFX942 APU & MI300A \\
+@@ -670,7 +670,7 @@
  \begin{tabularx}{\linewidth}{lllX}
  \toprule
  
@@ -18,12 +27,3 @@
  cards} \\ \midrule
  
  \texttt{-DKokkos\_ARCH\_HOPPER90=ON} & Hopper & 9.0 & H200, H100 \\
-@@ -639,7 +639,7 @@
-     \ExtensionTok{{-}DKokkos\_ENABLE\_SYCL}\NormalTok{=ON }\KeywordTok{\textbackslash{}}
-     \ExtensionTok{{-}DKokkos\_ARCH\_INTEL\_PVC}\NormalTok{=ON }\KeywordTok{\textbackslash{}}
-     \ExtensionTok{{-}DKokkos\_ENABLE\_OPENMP}\NormalTok{=ON }\KeywordTok{\textbackslash{}}
--    \ExtensionTok{{-}DCMAKE\_CXX\_FLAGS}\NormalTok{=}\StringTok{"{-}fp{-}model=precise"}\NormalTok{  \# for math precision}
-+    \ExtensionTok{{-}DCMAKE\_CXX\_FLAGS}\NormalTok{=}\StringTok{"{-}fp{-}model=precise"}\CommentTok{  \# for math precision}
- \end{Highlighting}
- \end{Shaded}
- 

--- a/patches/print/install.tex.diff
+++ b/patches/print/install.tex.diff
@@ -1,15 +1,15 @@
---- .install.tex	2025-02-21 20:31:49.235182630 +0100
-+++ install.tex	2025-02-21 20:32:21.670428339 +0100
-@@ -472,7 +472,7 @@
-     \KeywordTok{include}\NormalTok{(FetchContent)}
-     \FunctionTok{FetchContent\_Declare}\NormalTok{(}
- \NormalTok{        kokkos}
--\NormalTok{        URL https://github.com/kokkos/kokkos/releases/download/x.y.z/kokkos{-}x.y.z.zip}
-+\NormalTok{        URL https://github.com/kokkos/kokkos/releases/download/x.y.z/\break{}kokkos{-}x.y.z.zip}
- \NormalTok{    )}
-     \FunctionTok{FetchContent\_MakeAvailable}\NormalTok{(kokkos)}
- \KeywordTok{endif}\NormalTok{()}
-@@ -627,7 +627,7 @@
+--- .install.tex	2025-02-28 15:37:52.208429178 +0100
++++ install.tex	2025-02-28 15:38:14.746538842 +0100
+@@ -471,7 +471,7 @@
+ \KeywordTok{include}\NormalTok{(FetchContent)}
+ \FunctionTok{FetchContent\_Declare}\NormalTok{(}
+ \NormalTok{    kokkos}
+-\NormalTok{    URL https://github.com/kokkos/kokkos/releases/download/x.y.z/kokkos{-}x.y.z.zip}
++\NormalTok{    URL https://github.com/kokkos/kokkos/releases/download/x.y.z/\break{}kokkos{-}x.y.z.zip}
+ \NormalTok{)}
+ \FunctionTok{FetchContent\_MakeAvailable}\NormalTok{(kokkos)}
+ \KeywordTok{target\_link\_libraries}\NormalTok{(}
+@@ -645,7 +645,7 @@
  \begin{tabularx}{\linewidth}{llX}
  \toprule
  
@@ -18,7 +18,7 @@
  cards} \\ \midrule
  
  \texttt{-DKokkos\_ARCH\_AMD\_GFX942\_APU=ON} & GFX942 APU & MI300A \\
-@@ -670,7 +670,7 @@
+@@ -688,7 +688,7 @@
  \begin{tabularx}{\linewidth}{lllX}
  \toprule
  


### PR DESCRIPTION
Add a section to integrate Kokkos with CMake FetchContent. The hybrid external/internal dependency code cannot be displayed due to insufficient space on the pages. Not a perfect solution, but it's aligned with the official documentation.

Preview:

![Capture d’écran du 2025-05-16 14-48-37](https://github.com/user-attachments/assets/e246286a-d1d5-4e82-a999-44f6880d7a76)


