### PR TITLE
Update architectures

### DIFF
--- a/install.md
+++ b/install.md
@@ -357,11 +357,11 @@ They can be deduced from the device if present at CMake configuration time.
 cmake \
     -B build \
     -DCMAKE_BUILD_TYPE=Release \
-    -DKokkos_ARCH_NATIVE=ON \
-    -DKokkos_ENABLE_OPENMP=ON
+    -DKokkos_ENABLE_OPENMP=ON \
+    -DKokkos_ARCH_NATIVE=ON
 ```
 
-#### AMD MI250 GPU with HIP and OpenMP
+#### AMD MI250 GPU with HIP
 
 ```sh
 cmake \
@@ -369,33 +369,30 @@ cmake \
     -DCMAKE_CXX_COMPILER=hipcc \
     -DCMAKE_BUILD_TYPE=Release \
     -DKokkos_ENABLE_HIP=ON \
-    -DKokkos_ARCH_AMD_GFX90A=ON \
-    -DKokkos_ENABLE_OPENMP=ON
+    -DKokkos_ARCH_AMD_GFX90A=ON
 ```
 
-#### NVIDIA A100 GPU with CUDA and OpenMP
+#### NVIDIA H100 GPU with CUDA
 
 ```sh
 cmake \
     -B build \
     -DCMAKE_BUILD_TYPE=Release \
     -DKokkos_ENABLE_CUDA=ON \
-    -DKokkos_ARCH_AMPERE80=ON \
-    -DKokkos_ENABLE_OPENMP=ON
+    -DKokkos_ARCH_HOPPER90=ON
 ```
 
-#### NVIDIA V100 GPU with CUDA and OpenMP
+#### NVIDIA A100 GPU with CUDA
 
 ```sh
 cmake \
     -B build \
     -DCMAKE_BUILD_TYPE=Release \
     -DKokkos_ENABLE_CUDA=ON \
-    -DKokkos_ARCH_VOLTA70=ON \
-    -DKokkos_ENABLE_OPENMP=ON
+    -DKokkos_ARCH_AMPERE80=ON
 ```
 
-#### Intel GPU Max/Ponte Vecchio GPU with SYCL and OpenMP
+#### Intel GPU Max with SYCL
 
 ```sh
 cmake \
@@ -404,7 +401,6 @@ cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DKokkos_ENABLE_SYCL=ON \
     -DKokkos_ARCH_INTEL_PVC=ON \
-    -DKokkos_ENABLE_OPENMP=ON \
     -DCMAKE_CXX_FLAGS="-fp-model=precise"
 ```
 

--- a/install.md
+++ b/install.md
@@ -286,14 +286,14 @@ They can be deduced from the device if present at CMake configuration time.
 
 </summary>
 
-| Option                         | Architecture          |
-|--------------------------------|-----------------------|
-| `-DKokkos_ARCH_INTEL_GEN=ON`   | Generic JIT           |
-| `-DKokkos_ARCH_INTEL_XEHP=ON`  | Xe-HP                 |
-| `-DKokkos_ARCH_INTEL_PVC=ON`   | GPU Max/Ponte Vecchio |
-| `-DKokkos_ARCH_INTEL_DG1=ON`   | Iris XeMAX            |
-| `-DKokkos_ARCH_INTEL_GEN12=ON` | Gen12                 |
-| `-DKokkos_ARCH_INTEL_GEN11=ON` | Gen11                 |
+| Option                         | Architecture            |
+|--------------------------------|-------------------------|
+| `-DKokkos_ARCH_INTEL_GEN=ON`   | Generic JIT             |
+| `-DKokkos_ARCH_INTEL_XEHP=ON`  | Xe-HP                   |
+| `-DKokkos_ARCH_INTEL_PVC=ON`   | GPU Max (Ponte Vecchio) |
+| `-DKokkos_ARCH_INTEL_DG1=ON`   | Iris XeMAX              |
+| `-DKokkos_ARCH_INTEL_GEN12=ON` | Gen12                   |
+| `-DKokkos_ARCH_INTEL_GEN11=ON` | Gen11                   |
 
 <!--#ifndef PRINT-->
 
@@ -386,6 +386,20 @@ cmake \
     -DKokkos_ARCH_AMD_GFX90A=ON
 ```
 
+#### Intel GPU Max 1550 (Ponte Vecchio) with SYCL
+
+```sh
+cmake \
+    -B build \
+    -DCMAKE_CXX_COMPILER=icpx \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DKokkos_ENABLE_SYCL=ON \
+    -DKokkos_ARCH_INTEL_PVC=ON \
+    -DCMAKE_CXX_FLAGS="-fp-model=precise"
+```
+
+Last option is for math operators precision.
+
 #### NVIDIA H100 GPU with CUDA
 
 ```sh
@@ -405,20 +419,6 @@ cmake \
     -DKokkos_ENABLE_CUDA=ON \
     -DKokkos_ARCH_AMPERE80=ON
 ```
-
-#### Intel GPU Max with SYCL
-
-```sh
-cmake \
-    -B build \
-    -DCMAKE_CXX_COMPILER=icpx \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DKokkos_ENABLE_SYCL=ON \
-    -DKokkos_ARCH_INTEL_PVC=ON \
-    -DCMAKE_CXX_FLAGS="-fp-model=precise"
-```
-
-Last option is for math operators precision.
 
 <!--#ifndef PRINT-->
 <img title="Code" alt="Code" src="./images/code_txt.svg" height="25"> For more code examples:

--- a/install.md
+++ b/install.md
@@ -361,6 +361,20 @@ cmake \
     -DKokkos_ARCH_NATIVE=ON
 ```
 
+#### AMD MI300A APU with HIP
+
+```sh
+export HSA_XNACK=1
+cmake \
+    -B build \
+    -DCMAKE_CXX_COMPILER=hipcc \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DKokkos_ENABLE_HIP=ON \
+    -DKokkos_ARCH_AMD_GFX942_APU=ON
+```
+
+Environment variable is required to access host allocations from the device.
+
 #### AMD MI250 GPU with HIP
 
 ```sh

--- a/install.md
+++ b/install.md
@@ -326,10 +326,6 @@ They can be deduced from the device if present at CMake configuration time.
 | `-DKokkos_ARCH_MAXWELL53=ON` | Maxwell      | 5.3 |                                                        |
 | `-DKokkos_ARCH_MAXWELL52=ON` | Maxwell      | 5.2 | M6, M60, M4, M40                                       |
 | `-DKokkos_ARCH_MAXWELL50=ON` | Maxwell      | 5.0 | M10                                                    |
-| `-DKokkos_ARCH_KEPLER37=ON`  | Kepler       | 3.7 | K80                                                    |
-| `-DKokkos_ARCH_KEPLER35=ON`  | Kepler       | 3.5 | K40, K20                                               |
-| `-DKokkos_ARCH_KEPLER32=ON`  | Kepler       | 3.2 |                                                        |
-| `-DKokkos_ARCH_KEPLER30=ON`  | Kepler       | 3.0 | K10                                                    |
 
 <!--#ifndef PRINT-->
 

--- a/typos.toml
+++ b/typos.toml
@@ -5,3 +5,4 @@ extend-exclude = [
 
 [default.extend-words]
 ND = "ND"
+HSA = "HSA"


### PR DESCRIPTION
This PR removes old architectures and updates example configurations.

Fixes #40.

In the examples section, hybrid configurations with both the OpenMP backend and a device backend now only use a device backend. This can be subject to debates, however.